### PR TITLE
userspace socket: trigger Write event when peer handle is closed

### DIFF
--- a/source/extensions/io_socket/user_space/io_handle_impl.h
+++ b/source/extensions/io_socket/user_space/io_handle_impl.h
@@ -124,6 +124,11 @@ public:
   void onPeerDestroy() override {
     peer_handle_ = nullptr;
     sent_eof_ = true;
+    if (user_file_event_) {
+      // The connection may be waiting to flush a write to the socket, so activate the Write event
+      // so that the connection can clean up.
+      user_file_event_->activateIfEnabled(Event::FileReadyType::Write);
+    }
   }
   void onPeerBufferLowWatermark() override {
     if (user_file_event_) {

--- a/test/extensions/io_socket/user_space/io_handle_impl_test.cc
+++ b/test/extensions/io_socket/user_space/io_handle_impl_test.cc
@@ -1059,6 +1059,32 @@ TEST_F(IoHandleImplTest, NotifyWritableAfterShutdownWrite) {
   io_handle_peer_->close();
 }
 
+// When a handle is closed, its peer gets signalled to drain any data it has left to write-flush.
+TEST_F(IoHandleImplTest, NotifyWritableAfterClose) {
+  io_handle_peer_->setWatermarks(128);
+
+  Buffer::OwnedImpl buf(std::string(256, 'a'));
+  io_handle_->write(buf);
+  EXPECT_FALSE(io_handle_peer_->canReceiveData());
+
+  auto schedulable_cb = new NiceMock<Event::MockSchedulableCallback>(&dispatcher_);
+  io_handle_->initializeFileEvent(
+      dispatcher_,
+      [this](uint32_t events) {
+        cb_.called(events);
+        return absl::OkStatus();
+      },
+      Event::FileTriggerType::Edge, Event::FileReadyType::Write);
+  // The peer's receive buffer is full, so no Write event is raised.
+  ASSERT_FALSE(schedulable_cb->enabled_);
+
+  // We suddenly close the peer handle, even though there is data left to send to it.
+  io_handle_peer_->close();
+  EXPECT_TRUE(schedulable_cb->enabled_);
+  EXPECT_CALL(cb_, called(Event::FileReadyType::Write));
+  schedulable_cb->invokeCallback();
+}
+
 TEST_F(IoHandleImplTest, ReturnValidInternalAddress) {
   const auto local_address = *io_handle_->localAddress();
   ASSERT_NE(nullptr, local_address);

--- a/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
+++ b/test/extensions/transport_sockets/internal_upstream/internal_upstream_integration_test.cc
@@ -325,5 +325,31 @@ TEST_F(InternalUpstreamIntegrationTest, InternalConnectionBufSizeTest5KB) {
                       internalConnectionBufferSizeTest());
 }
 
+TEST_F(InternalUpstreamIntegrationTest, TcpProxyHalfCloseLeak) {
+  // Setup the environment with the internal listeners and TCP proxy filter chains.
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  auto response =
+      codec_client_->makeRequestWithBody(default_request_headers_, 1024, true /* end_stream */);
+  waitForNextUpstreamRequest();
+
+  // Tear down the client side of the internal connection. This leaves the server side of the
+  // internal connection unaware that the client is dead.
+  codec_client_->close();
+
+  // Upstream sends final data and immediately closes. This puts the internal connection into the
+  // CloseAfterFlush state waiting for a Write event to drain the buffer.
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeData(1024, true);
+  // Cast to void to satisfy [[nodiscard]] attribute.
+  (void)fake_upstream_connection_->close();
+
+  // Verify that the connection does not leak by waiting for the active connection gauge to drop to
+  // zero. If the server side of the internal connection fails to clean up the downstream connection
+  // then this wait will time out because the connection is stuck in CloseAfterFlush indefinitely.
+  test_server_->waitForGaugeEq("listener.envoy_internal_internal_listener.downstream_cx_active", 0);
+}
+
 } // namespace
 } // namespace Envoy


### PR DESCRIPTION
Commit Message: userspace socket: trigger Write event when peer handle is closed
Additional Description:
If one side of an internal listener connection closes the connection while the other side has data waiting to be flushed on a half-close, the other side will never be signalled that the connection is closed and will hold onto the connection indefinitely. For connections managed by the HCM, this is covered by the delayed close timer, but TcpProxy does not implement a delayed close timer and therefore the connection leak in #38148 can occur.

The fix here is to signal the Write event in onPeerDestroy when the peer handle is closed. This will trigger the owner of the peer handle to do a write if it still has data to flush, which will error out and cause the connection to be torn down.
Risk Level: low
Testing: new CI and integration test that reproduces the issue
Docs Changes: n/a
Release Notes: n/a
Fixes #38148